### PR TITLE
new parsing of version # in linux

### DIFF
--- a/src/kernelpop.py
+++ b/src/kernelpop.py
@@ -169,9 +169,9 @@ class Kernel:
 				# Linux kali 4.13.0-kali1-amd64 #1 SMP Debian 4.13.4-2kali1 (2017-10-16) x86_64 GNU/Linux
 				if "kali" in kernel_version.lower():
 					k_release = int(kernel_version.split(" ")[-4].split("-")[0].split(".")[2])
-					pass
 				else:
-					k_release = int(kernel_version.split(" ")[2].split("-")[1])
+					k_release = int(''.join(c for c in kernel_version.split(" ")[2].split("-")[1] if c.isdigit()))
+					print("")
 
 				return k_type, k_distro, k_name, k_major, k_minor, k_release, k_architecture, kernel_version
 

--- a/test/test_get_kernel_version.py
+++ b/test/test_get_kernel_version.py
@@ -52,5 +52,10 @@ class TestGetKernelVersion(unittest.TestCase):
 		self.assertEqual(test_kali_kernel_1.release, 4)
 		self.assertEqual(test_kali_kernel_2.release, 25)
 
+	def test_diff_uname(self):
+		test_uname = "Linux amd64 4.14.0-rc7+ #18 SMP PREEMPT Sun Nov 5 05:52:33 MSK 2017 x86_64 GNU/Linux"
+		test_uname_kernel = Kernel(test_uname, uname=True)
+		self.assertEqual(test_uname_kernel.release, 7)
+
 if __name__ ==  "__main__":
 	unittest.main()


### PR DESCRIPTION
quick fix so that unames with the kernel version formatted like `4.14.0-rc7+` does not crash the program.

example uname:

```
Linux amd64 4.14.0-rc7+ #18 SMP PREEMPT Sun Nov 5 05:52:33 MSK 2017 x86_64 GNU/Linux
```