### PR TITLE
[mac os] fix crash when sw_vers doesn't include release version number

### DIFF
--- a/src/kernelpop.py
+++ b/src/kernelpop.py
@@ -241,7 +241,10 @@ def get_mac_version():
 	mac_v = shell_results(v_command)[0].decode("utf-8")
 	v_major = int(mac_v.split("\n")[1].split(":")[1].split(".")[0])
 	v_minor = int(mac_v.split("\n")[1].split(":")[1].split(".")[1])
-	v_release = int(mac_v.split("\n")[1].split(":")[1].split(".")[2])
+	try:
+		v_release = int(mac_v.split("\n")[1].split(":")[1].split(".")[2])
+	except:
+		v_release = 0
 
 	return v_major, v_minor, v_release
 


### PR DESCRIPTION
Apple doesn't include the last number for the first version of each os, for instance on 10.13 `sw_vers` produces:
```
ProductName:	Mac OS X
ProductVersion:	10.13
BuildVersion:	17A405
```
This patch safely handles this case.

@spencerdodd 